### PR TITLE
Add lifecycle demo component with lifecycle hooks

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,7 @@
 import { Routes } from '@angular/router';
+import { LifecycleDemoComponent } from './lifecycle-demo/lifecycle-demo.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: 'lifecycle-demo', component: LifecycleDemoComponent }
+];
+

--- a/src/app/lifecycle-demo/lifecycle-demo.component.html
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.html
@@ -1,0 +1,1 @@
+<p>lifecycle-demo works!</p>

--- a/src/app/lifecycle-demo/lifecycle-demo.component.scss
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.scss
@@ -1,0 +1,1 @@
+/* Styles for LifecycleDemoComponent */

--- a/src/app/lifecycle-demo/lifecycle-demo.component.spec.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.spec.ts
@@ -1,0 +1,18 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { LifecycleDemoComponent } from './lifecycle-demo.component';
+
+describe('LifecycleDemoComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LifecycleDemoComponent],
+      providers: [provideZonelessChangeDetection()]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(LifecycleDemoComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/lifecycle-demo/lifecycle-demo.component.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit, OnDestroy, OnChanges, SimpleChanges, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked } from '@angular/core';
+
+@Component({
+  selector: 'app-lifecycle-demo',
+  standalone: true,
+  templateUrl: './lifecycle-demo.component.html',
+  styleUrl: './lifecycle-demo.component.scss'
+})
+export class LifecycleDemoComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy {
+  ngOnChanges(changes: SimpleChanges): void {
+    console.log('LifecycleDemoComponent ngOnChanges', changes);
+  }
+
+  ngOnInit(): void {
+    console.log('LifecycleDemoComponent ngOnInit');
+  }
+
+  ngDoCheck(): void {
+    console.log('LifecycleDemoComponent ngDoCheck');
+  }
+
+  ngAfterContentInit(): void {
+    console.log('LifecycleDemoComponent ngAfterContentInit');
+  }
+
+  ngAfterContentChecked(): void {
+    console.log('LifecycleDemoComponent ngAfterContentChecked');
+  }
+
+  ngAfterViewInit(): void {
+    console.log('LifecycleDemoComponent ngAfterViewInit');
+  }
+
+  ngAfterViewChecked(): void {
+    console.log('LifecycleDemoComponent ngAfterViewChecked');
+  }
+
+  ngOnDestroy(): void {
+    console.log('LifecycleDemoComponent ngOnDestroy');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `LifecycleDemoComponent` implementing all Angular lifecycle hooks with console log outputs
- register `/lifecycle-demo` route
- include accompanying template, styles and spec

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa79057208321be6393c9bc049ada