### PR TITLE
Add lifecycle hook tests and cheatsheet

### DIFF
--- a/LIFECYCLE_HOOKS_CHEATSHEET.md
+++ b/LIFECYCLE_HOOKS_CHEATSHEET.md
@@ -1,0 +1,13 @@
+# Angular Lifecycle Hooks Cheatsheet
+
+| Hook | Description |
+| --- | --- |
+| **ngOnChanges** | Called when an `@Input()` property value changes. Provides a `SimpleChanges` object of current and previous values. |
+| **ngOnInit** | Invoked once after the first `ngOnChanges`. Use it for component initialization. |
+| **ngDoCheck** | Runs during every change detection cycle and lets you implement custom change detection. |
+| **ngAfterContentInit** | Called once after Angular projects external content into the component. |
+| **ngAfterContentChecked** | Invoked after every check of projected content. |
+| **ngAfterViewInit** | Runs after Angular initializes the component's views and child views. |
+| **ngAfterViewChecked** | Called after every check of the component's views and child views. |
+| **ngOnDestroy** | Invoked just before Angular destroys the component; use it for cleanup. |
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This project includes a `LifecycleDemoComponent` and a nested `LifecycleChildCom
 - **AfterViewChecked** – executes after Angular checks the component's views and child views.
 - **OnDestroy** – invoked just before Angular destroys the component.
 
+For a quick reference, see the [Lifecycle Hooks Cheatsheet](LIFECYCLE_HOOKS_CHEATSHEET.md).
+
 ### Running the demo
 
 1. Start the development server:

--- a/src/app/lifecycle-demo/lifecycle-demo.component.spec.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.spec.ts
@@ -3,7 +3,10 @@ import { TestBed } from '@angular/core/testing';
 import { LifecycleDemoComponent } from './lifecycle-demo.component';
 
 describe('LifecycleDemoComponent', () => {
+  let consoleSpy: jasmine.Spy;
+
   beforeEach(async () => {
+    consoleSpy = spyOn(console, 'log');
     await TestBed.configureTestingModule({
       imports: [LifecycleDemoComponent],
       providers: [provideZonelessChangeDetection()]
@@ -14,5 +17,29 @@ describe('LifecycleDemoComponent', () => {
     const fixture = TestBed.createComponent(LifecycleDemoComponent);
     const component = fixture.componentInstance;
     expect(component).toBeTruthy();
+  });
+
+  it('should log ngOnInit on initialization', () => {
+    const fixture = TestBed.createComponent(LifecycleDemoComponent);
+    fixture.detectChanges();
+    expect(consoleSpy).toHaveBeenCalledWith('LifecycleDemoComponent ngOnInit');
+  });
+
+  it('should log ngOnChanges when inputValue changes', () => {
+    const fixture = TestBed.createComponent(LifecycleDemoComponent);
+    fixture.detectChanges();
+    consoleSpy.calls.reset();
+    const component = fixture.componentInstance;
+    component.inputValue = 'test';
+    fixture.detectChanges();
+    expect(consoleSpy).toHaveBeenCalledWith('LifecycleDemoComponent ngOnChanges', jasmine.any(Object));
+  });
+
+  it('should log ngOnDestroy when destroyed', () => {
+    const fixture = TestBed.createComponent(LifecycleDemoComponent);
+    fixture.detectChanges();
+    consoleSpy.calls.reset();
+    fixture.destroy();
+    expect(consoleSpy).toHaveBeenCalledWith('LifecycleDemoComponent ngOnDestroy');
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests covering initialization, input changes, and destruction hooks
- create lifecycle hooks cheatsheet and link from README

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68baba603264832181b56184954da4a8