### PR TITLE
feat: add UI controls and logs for lifecycle demo

### DIFF
--- a/src/app/lifecycle-demo/child/child.component.html
+++ b/src/app/lifecycle-demo/child/child.component.html
@@ -1,1 +1,14 @@
-<p>child works! {{ inputValue }}</p>
+<div>
+  <h3>Child Component</h3>
+  <p>From parent: {{ inputValue }}</p>
+  <input #val />
+  <button (click)="childValue = val.value">Set Child Value</button>
+  <p>Child value: {{ childValue }}</p>
+  <button (click)="startTimer()">Start Timer</button>
+  <button (click)="stopTimer()">Stop Timer</button>
+  <p>Timer: {{ counter }}</p>
+  <h4>Logs</h4>
+  <ul>
+    <li *ngFor="let log of logs">{{ log }}</li>
+  </ul>
+</div>

--- a/src/app/lifecycle-demo/child/child.component.ts
+++ b/src/app/lifecycle-demo/child/child.component.ts
@@ -11,46 +11,75 @@ import {
   AfterViewChecked,
   Input,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-child',
   standalone: true,
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './child.component.html',
   styleUrl: './child.component.scss'
 })
-export class LifecycleChildComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy {
+export class LifecycleChildComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit,
+  AfterViewChecked, OnDestroy {
   @Input() inputValue = '';
+  logs: string[] = [];
+  childValue = '';
+  counter = 0;
+  intervalId?: ReturnType<typeof setInterval>;
+
+  log(message: string, data?: any) {
+    this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
+    data !== undefined ? console.log(message, data) : console.log(message);
+  }
+
+  startTimer() {
+    if (!this.intervalId) {
+      this.intervalId = setInterval(() => {
+        this.counter++;
+        this.log(`Child timer tick ${this.counter}`);
+      }, 1000);
+    }
+  }
+
+  stopTimer() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+      this.log('Child timer stopped');
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
-    console.log('LifecycleChildComponent ngOnChanges', changes);
+    this.log('LifecycleChildComponent ngOnChanges', changes);
   }
 
   ngOnInit(): void {
-    console.log('LifecycleChildComponent ngOnInit');
+    this.log('LifecycleChildComponent ngOnInit');
   }
 
   ngDoCheck(): void {
-    console.log('LifecycleChildComponent ngDoCheck', this.inputValue);
+    this.log('LifecycleChildComponent ngDoCheck', this.inputValue);
   }
 
   ngAfterContentInit(): void {
-    console.log('LifecycleChildComponent ngAfterContentInit');
+    this.log('LifecycleChildComponent ngAfterContentInit');
   }
 
   ngAfterContentChecked(): void {
-    console.log('LifecycleChildComponent ngAfterContentChecked');
+    this.log('LifecycleChildComponent ngAfterContentChecked');
   }
 
   ngAfterViewInit(): void {
-    console.log('LifecycleChildComponent ngAfterViewInit');
+    this.log('LifecycleChildComponent ngAfterViewInit');
   }
 
   ngAfterViewChecked(): void {
-    console.log('LifecycleChildComponent ngAfterViewChecked');
+    this.log('LifecycleChildComponent ngAfterViewChecked');
   }
 
   ngOnDestroy(): void {
-    console.log('LifecycleChildComponent ngOnDestroy');
+    this.log('LifecycleChildComponent ngOnDestroy');
+    this.stopTimer();
   }
 }

--- a/src/app/lifecycle-demo/lifecycle-demo.component.html
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.html
@@ -1,4 +1,16 @@
-<p>lifecycle-demo works!</p>
-<input #val />
-<button (click)="inputValue = val.value">Update Input</button>
-<app-child [inputValue]="inputValue"></app-child>
+<div>
+  <h2>Lifecycle Demo</h2>
+  <input #val />
+  <button (click)="inputValue = val.value">Update Input</button>
+  <button (click)="startTimer()">Start Timer</button>
+  <button (click)="stopTimer()">Stop Timer</button>
+  <button (click)="toggleChild()">Toggle Child</button>
+  <p>Timer: {{ counter }}</p>
+
+  <app-child *ngIf="showChild" [inputValue]="inputValue"></app-child>
+
+  <h3>Logs</h3>
+  <ul>
+    <li *ngFor="let log of logs">{{ log }}</li>
+  </ul>
+</div>

--- a/src/app/lifecycle-demo/lifecycle-demo.component.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.ts
@@ -11,48 +11,80 @@ import {
   AfterViewChecked,
   Input,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { LifecycleChildComponent } from './child/child.component';
 
 @Component({
   selector: 'app-lifecycle-demo',
   standalone: true,
-  imports: [LifecycleChildComponent],
+  imports: [CommonModule, LifecycleChildComponent],
   templateUrl: './lifecycle-demo.component.html',
   styleUrl: './lifecycle-demo.component.scss'
 })
 export class LifecycleDemoComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit,
   AfterViewChecked, OnDestroy {
   @Input() inputValue = '';
+  logs: string[] = [];
+  showChild = true;
+  counter = 0;
+  intervalId?: ReturnType<typeof setInterval>;
+
+  log(message: string, data?: any) {
+    this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
+    data !== undefined ? console.log(message, data) : console.log(message);
+  }
+
+  startTimer() {
+    if (!this.intervalId) {
+      this.intervalId = setInterval(() => {
+        this.counter++;
+        this.log(`Timer tick ${this.counter}`);
+      }, 1000);
+    }
+  }
+
+  stopTimer() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+      this.log('Timer stopped');
+    }
+  }
+
+  toggleChild() {
+    this.showChild = !this.showChild;
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
-    console.log('LifecycleDemoComponent ngOnChanges', changes);
+    this.log('LifecycleDemoComponent ngOnChanges', changes);
   }
 
   ngOnInit(): void {
-    console.log('LifecycleDemoComponent ngOnInit');
+    this.log('LifecycleDemoComponent ngOnInit');
   }
 
   ngDoCheck(): void {
-    console.log('LifecycleDemoComponent ngDoCheck', this.inputValue);
+    this.log('LifecycleDemoComponent ngDoCheck', this.inputValue);
   }
 
   ngAfterContentInit(): void {
-    console.log('LifecycleDemoComponent ngAfterContentInit');
+    this.log('LifecycleDemoComponent ngAfterContentInit');
   }
 
   ngAfterContentChecked(): void {
-    console.log('LifecycleDemoComponent ngAfterContentChecked');
+    this.log('LifecycleDemoComponent ngAfterContentChecked');
   }
 
   ngAfterViewInit(): void {
-    console.log('LifecycleDemoComponent ngAfterViewInit');
+    this.log('LifecycleDemoComponent ngAfterViewInit');
   }
 
   ngAfterViewChecked(): void {
-    console.log('LifecycleDemoComponent ngAfterViewChecked');
+    this.log('LifecycleDemoComponent ngAfterViewChecked');
   }
 
   ngOnDestroy(): void {
-    console.log('LifecycleDemoComponent ngOnDestroy');
+    this.log('LifecycleDemoComponent ngOnDestroy');
+    this.stopTimer();
   }
 }


### PR DESCRIPTION
## Summary
- show lifecycle logs in parent and child components
- add timer controls and child toggling to observe hooks

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68bacef53cc48321a243ae59aeb0fc97