### PR TITLE
style: add responsive cards and themed logs

### DIFF
--- a/src/app/lifecycle-demo/child/child.component.html
+++ b/src/app/lifecycle-demo/child/child.component.html
@@ -1,14 +1,16 @@
-<div>
+<div class="card child-container">
   <h3>Child Component</h3>
   <p>From parent: {{ inputValue }}</p>
-  <input #val />
-  <button (click)="childValue = val.value">Set Child Value</button>
+  <div class="controls">
+    <input #val />
+    <button (click)="childValue = val.value">Set Child Value</button>
+    <button (click)="startTimer()">Start Timer</button>
+    <button (click)="stopTimer()">Stop Timer</button>
+  </div>
   <p>Child value: {{ childValue }}</p>
-  <button (click)="startTimer()">Start Timer</button>
-  <button (click)="stopTimer()">Stop Timer</button>
   <p>Timer: {{ counter }}</p>
   <h4>Logs</h4>
-  <ul>
-    <li *ngFor="let log of logs">{{ log }}</li>
+  <ul class="logs">
+    <li *ngFor="let log of logs" [ngClass]="getLogClass(log)">{{ log }}</li>
   </ul>
 </div>

--- a/src/app/lifecycle-demo/child/child.component.scss
+++ b/src/app/lifecycle-demo/child/child.component.scss
@@ -1,0 +1,22 @@
+.child-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.logs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.logs li {
+  padding: 0.25rem 0;
+}

--- a/src/app/lifecycle-demo/child/child.component.ts
+++ b/src/app/lifecycle-demo/child/child.component.ts
@@ -28,6 +28,17 @@ export class LifecycleChildComponent implements OnChanges, OnInit, DoCheck, Afte
   counter = 0;
   intervalId?: ReturnType<typeof setInterval>;
 
+  getLogClass(entry: string): string {
+    const lower = entry.toLowerCase();
+    if (lower.includes('timer')) {
+      return 'log-timer';
+    }
+    if (lower.includes('destroy')) {
+      return 'log-destroy';
+    }
+    return 'log-lifecycle';
+  }
+
   log(message: string, data?: any) {
     this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
     data !== undefined ? console.log(message, data) : console.log(message);

--- a/src/app/lifecycle-demo/lifecycle-demo.component.html
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.html
@@ -1,16 +1,18 @@
-<div>
+<div class="card demo-container">
   <h2>Lifecycle Demo</h2>
-  <input #val />
-  <button (click)="inputValue = val.value">Update Input</button>
-  <button (click)="startTimer()">Start Timer</button>
-  <button (click)="stopTimer()">Stop Timer</button>
-  <button (click)="toggleChild()">Toggle Child</button>
+  <div class="controls">
+    <input #val />
+    <button (click)="inputValue = val.value">Update Input</button>
+    <button (click)="startTimer()">Start Timer</button>
+    <button (click)="stopTimer()">Stop Timer</button>
+    <button (click)="toggleChild()">Toggle Child</button>
+  </div>
   <p>Timer: {{ counter }}</p>
 
   <app-child *ngIf="showChild" [inputValue]="inputValue"></app-child>
 
   <h3>Logs</h3>
-  <ul>
-    <li *ngFor="let log of logs">{{ log }}</li>
+  <ul class="logs">
+    <li *ngFor="let log of logs" [ngClass]="getLogClass(log)">{{ log }}</li>
   </ul>
 </div>

--- a/src/app/lifecycle-demo/lifecycle-demo.component.scss
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.scss
@@ -1,1 +1,24 @@
 /* Styles for LifecycleDemoComponent */
+
+.demo-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.logs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.logs li {
+  padding: 0.25rem 0;
+}

--- a/src/app/lifecycle-demo/lifecycle-demo.component.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.ts
@@ -29,6 +29,17 @@ export class LifecycleDemoComponent implements OnChanges, OnInit, DoCheck, After
   counter = 0;
   intervalId?: ReturnType<typeof setInterval>;
 
+  getLogClass(entry: string): string {
+    const lower = entry.toLowerCase();
+    if (lower.includes('timer')) {
+      return 'log-timer';
+    }
+    if (lower.includes('destroy')) {
+      return 'log-destroy';
+    }
+    return 'log-lifecycle';
+  }
+
   log(message: string, data?: any) {
     this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
     data !== undefined ? console.log(message, data) : console.log(message);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,34 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global theme and shared styles */
+
+:root {
+  --primary-color: #1976d2;
+  --lifecycle-color: #388e3c;
+  --warn-color: #d32f2f;
+  --bg-color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--bg-color);
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  margin: 1rem auto;
+}
+
+.log-timer {
+  color: var(--primary-color);
+}
+
+.log-lifecycle {
+  color: var(--lifecycle-color);
+}
+
+.log-destroy {
+  color: var(--warn-color);
+}


### PR DESCRIPTION
## Summary
- add global CSS theme with card styling and log colors
- style lifecycle demo and child components with responsive flex layouts
- color-code lifecycle and timer logs

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68bad17925548321acf2f82af415836f