### PR TITLE
feat: remove on-page log output

### DIFF
--- a/src/app/lifecycle-demo/child/child.component.html
+++ b/src/app/lifecycle-demo/child/child.component.html
@@ -9,8 +9,4 @@
   </div>
   <p>Child value: {{ childValue }}</p>
   <p>Timer: {{ counter }}</p>
-  <h4>Logs</h4>
-  <ul class="logs">
-    <li *ngFor="let log of logs" [ngClass]="getLogClass(log)">{{ log }}</li>
-  </ul>
 </div>

--- a/src/app/lifecycle-demo/child/child.component.scss
+++ b/src/app/lifecycle-demo/child/child.component.scss
@@ -11,12 +11,3 @@
   gap: 0.5rem;
 }
 
-.logs {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.logs li {
-  padding: 0.25rem 0;
-}

--- a/src/app/lifecycle-demo/child/child.component.ts
+++ b/src/app/lifecycle-demo/child/child.component.ts
@@ -23,24 +23,11 @@ import { CommonModule } from '@angular/common';
 export class LifecycleChildComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit,
   AfterViewChecked, OnDestroy {
   @Input() inputValue = '';
-  logs: string[] = [];
   childValue = '';
   counter = 0;
   intervalId?: ReturnType<typeof setInterval>;
 
-  getLogClass(entry: string): string {
-    const lower = entry.toLowerCase();
-    if (lower.includes('timer')) {
-      return 'log-timer';
-    }
-    if (lower.includes('destroy')) {
-      return 'log-destroy';
-    }
-    return 'log-lifecycle';
-  }
-
   log(message: string, data?: any) {
-    this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
     data !== undefined ? console.log(message, data) : console.log(message);
   }
 

--- a/src/app/lifecycle-demo/lifecycle-demo.component.html
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.html
@@ -10,9 +10,4 @@
   <p>Timer: {{ counter }}</p>
 
   <app-child *ngIf="showChild" [inputValue]="inputValue"></app-child>
-
-  <h3>Logs</h3>
-  <ul class="logs">
-    <li *ngFor="let log of logs" [ngClass]="getLogClass(log)">{{ log }}</li>
-  </ul>
 </div>

--- a/src/app/lifecycle-demo/lifecycle-demo.component.scss
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.scss
@@ -13,12 +13,3 @@
   gap: 0.5rem;
 }
 
-.logs {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.logs li {
-  padding: 0.25rem 0;
-}

--- a/src/app/lifecycle-demo/lifecycle-demo.component.ts
+++ b/src/app/lifecycle-demo/lifecycle-demo.component.ts
@@ -24,24 +24,11 @@ import { LifecycleChildComponent } from './child/child.component';
 export class LifecycleDemoComponent implements OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit,
   AfterViewChecked, OnDestroy {
   @Input() inputValue = '';
-  logs: string[] = [];
   showChild = true;
   counter = 0;
   intervalId?: ReturnType<typeof setInterval>;
 
-  getLogClass(entry: string): string {
-    const lower = entry.toLowerCase();
-    if (lower.includes('timer')) {
-      return 'log-timer';
-    }
-    if (lower.includes('destroy')) {
-      return 'log-destroy';
-    }
-    return 'log-lifecycle';
-  }
-
   log(message: string, data?: any) {
-    this.logs.push(data ? `${message} ${JSON.stringify(data)}` : message);
     data !== undefined ? console.log(message, data) : console.log(message);
   }
 


### PR DESCRIPTION
## Summary
- drop log lists from demo and child components
- console output only for lifecycle messages

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68baa277fff08321ae9fe6e174832105